### PR TITLE
docs: update message about this when using regular function

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ import { Traverse } from 'neotraverse/modern';
 
 const obj = { a: 1, b: 2, c: [3, 4] };
 
-new Traverse(obj).forEach(function (ctx, x) {
-  if (x < 0) ctx.update(x + 128); // `this` is `ctx` in modern build
+new Traverse(obj).forEach((ctx, x) => {
+  if (x < 0) ctx.update(x + 128); // `this` is same as `ctx` when using regular function
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ import { Traverse } from 'neotraverse/modern';
 
 const obj = { a: 1, b: 2, c: [3, 4] };
 
-new Traverse(obj).forEach((ctx, x) => {
+new Traverse(obj).forEach(function (ctx, x) {
   if (x < 0) ctx.update(x + 128); // `this` is `ctx` in modern build
 });
 ```


### PR DESCRIPTION
An arrow function cannot change the `this` context.

In the example before, `this` was always the global object (global in node, window in browser)