### PR TITLE
export map fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 
 .npmignore
 dist
+/legacy.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.6.12
+
+PINNED: traverse@0.6.9
+
+### Patch Changes
+
+Earlier, neotraverse/legacy did not work with WebPack 4, as it does not support export maps. Now this package provides direct fallback for CJS.
+
 ## 0.6.11
 
 PINNED: traverse@0.6.9

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
 		"./package.json": "./package.json"
 	},
 	"scripts": {
-		"compile": "tsup",
+		"compile": "tsup && cp dist/legacy/legacy.cjs legacy.js",
 		"test": "vitest run"
 	},
 	"repository": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
 	"type": "module",
 	"types": "dist/index.d.ts",
 	"files": [
-		"dist"
+		"dist",
+		"legacy.js"
 	],
 	"exports": {
 		".": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neotraverse",
-	"version": "0.6.11",
+	"version": "0.6.12",
 	"description": "traverse and transform objects by visiting every node on a recursive walk",
 	"main": "dist/legacy/legacy.cjs",
 	"type": "module",


### PR DESCRIPTION
Webpack 4 doesn't support export maps, it directly looks for legacy.js in top level. Hence this change provides fallback for this case.

Not providing simila fallbackf or modern as it assumes u are using a modern syntax