### PR TITLE
Top level legacy.d.ts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules/
 .npmignore
 dist
 /legacy.js
+/legacy.d.ts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.6.13
+
+PINNED: traverse@0.6.9
+
+### Patch Changes
+
+Fix types for neotraverse/legacy for pre-TypeScript 4.5(when export maps were not supported).
+
 ## 0.6.12
 
 PINNED: traverse@0.6.9

--- a/examples/pre-ts-4.5/.vscode/settings.json
+++ b/examples/pre-ts-4.5/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+	"typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/examples/pre-ts-4.5/index.ts
+++ b/examples/pre-ts-4.5/index.ts
@@ -1,0 +1,7 @@
+import traverse from 'neotraverse/legacy';
+
+const obj = { a: 1, b: 2, c: [3, 4] };
+
+traverse(obj).forEach(function (x) {
+	if (x < 0) this.update(x + 128);
+});

--- a/examples/pre-ts-4.5/package.json
+++ b/examples/pre-ts-4.5/package.json
@@ -1,0 +1,20 @@
+{
+	"name": "pre-ts-4.5",
+	"version": "1.0.0",
+	"private": true,
+	"main": "index.js",
+	"type": "module",
+	"scripts": {
+		"test": "echo \"Error: no test specified\" && exit 1"
+	},
+	"keywords": [],
+	"author": "",
+	"license": "ISC",
+	"description": "",
+	"dependencies": {
+		"neotraverse": "^0.6.12"
+	},
+	"devDependencies": {
+		"typescript": "^4.3.5"
+	}
+}

--- a/examples/pre-ts-4.5/pnpm-lock.yaml
+++ b/examples/pre-ts-4.5/pnpm-lock.yaml
@@ -1,0 +1,34 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      neotraverse:
+        specifier: ^0.6.12
+        version: 0.6.12
+    devDependencies:
+      typescript:
+        specifier: ^4.3.5
+        version: 4.3.5
+
+packages:
+
+  neotraverse@0.6.12:
+    resolution: {integrity: sha512-2+SB0CsPOjEs6f6PZ7ysDKANjn/jLPfJq65QWMQbEDPQWj/S/BzPkePhCDQRU5mmVquIl7FUt88DaCKGjfbZ3g==}
+    engines: {node: '>= 18'}
+
+  typescript@4.3.5:
+    resolution: {integrity: sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==}
+    engines: {node: '>=4.2.0'}
+    hasBin: true
+
+snapshots:
+
+  neotraverse@0.6.12: {}
+
+  typescript@4.3.5: {}

--- a/examples/try-esm/package.json
+++ b/examples/try-esm/package.json
@@ -11,6 +11,6 @@
 	"license": "ISC",
 	"description": "",
 	"dependencies": {
-		"neotraverse": "^0.6.12"
+		"neotraverse": "https://pkg.pr.new/PuruVJ/neotraverse@10"
 	}
 }

--- a/examples/try-esm/pnpm-lock.yaml
+++ b/examples/try-esm/pnpm-lock.yaml
@@ -9,15 +9,16 @@ importers:
   .:
     dependencies:
       neotraverse:
-        specifier: ^0.6.12
-        version: 0.6.12
+        specifier: https://pkg.pr.new/PuruVJ/neotraverse@10
+        version: https://pkg.pr.new/PuruVJ/neotraverse@10
 
 packages:
 
-  neotraverse@0.6.12:
-    resolution: {integrity: sha512-2+SB0CsPOjEs6f6PZ7ysDKANjn/jLPfJq65QWMQbEDPQWj/S/BzPkePhCDQRU5mmVquIl7FUt88DaCKGjfbZ3g==}
+  neotraverse@https://pkg.pr.new/PuruVJ/neotraverse@10:
+    resolution: {tarball: https://pkg.pr.new/PuruVJ/neotraverse@10}
+    version: 0.6.13
     engines: {node: '>= 18'}
 
 snapshots:
 
-  neotraverse@0.6.12: {}
+  neotraverse@https://pkg.pr.new/PuruVJ/neotraverse@10: {}

--- a/examples/try/index.js
+++ b/examples/try/index.js
@@ -1,4 +1,6 @@
-const traverse = require('neotraverse/legacy');
+const traverse = /** @type {import('neotraverse/legacy')['default']} */ (
+	require('neotraverse/legacy')
+);
 
 const obj = {
 	a: 1,

--- a/examples/try/package.json
+++ b/examples/try/package.json
@@ -1,15 +1,15 @@
 {
-  "name": "try",
-  "version": "1.0.0",
-  "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
-  "description": "",
-  "dependencies": {
-    "neotraverse": "https://pkg.pr.new/PuruVJ/neotraverse@d47bc4c"
-  }
+	"name": "try",
+	"version": "1.0.0",
+	"main": "index.js",
+	"scripts": {
+		"test": "echo \"Error: no test specified\" && exit 1"
+	},
+	"keywords": [],
+	"author": "",
+	"license": "ISC",
+	"description": "",
+	"dependencies": {
+		"neotraverse": "https://pkg.pr.new/PuruVJ/neotraverse@10"
+	}
 }

--- a/examples/try/pnpm-lock.yaml
+++ b/examples/try/pnpm-lock.yaml
@@ -9,16 +9,16 @@ importers:
   .:
     dependencies:
       neotraverse:
-        specifier: https://pkg.pr.new/PuruVJ/neotraverse@d47bc4c
-        version: https://pkg.pr.new/PuruVJ/neotraverse@d47bc4c
+        specifier: https://pkg.pr.new/PuruVJ/neotraverse@10
+        version: https://pkg.pr.new/PuruVJ/neotraverse@10
 
 packages:
 
-  neotraverse@https://pkg.pr.new/PuruVJ/neotraverse@d47bc4c:
-    resolution: {tarball: https://pkg.pr.new/PuruVJ/neotraverse@d47bc4c}
-    version: 0.6.9-next.0
+  neotraverse@https://pkg.pr.new/PuruVJ/neotraverse@10:
+    resolution: {tarball: https://pkg.pr.new/PuruVJ/neotraverse@10}
+    version: 0.6.13
     engines: {node: '>= 18'}
 
 snapshots:
 
-  neotraverse@https://pkg.pr.new/PuruVJ/neotraverse@d47bc4c: {}
+  neotraverse@https://pkg.pr.new/PuruVJ/neotraverse@10: {}

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
 	"name": "neotraverse",
-	"version": "0.6.12",
+	"version": "0.6.13",
 	"description": "traverse and transform objects by visiting every node on a recursive walk",
 	"main": "dist/legacy/legacy.cjs",
 	"type": "module",
 	"types": "dist/index.d.ts",
 	"files": [
 		"dist",
-		"legacy.js"
+		"legacy.*"
 	],
 	"exports": {
 		".": {
@@ -42,7 +42,7 @@
 		"./package.json": "./package.json"
 	},
 	"scripts": {
-		"compile": "tsup && cp dist/legacy/legacy.cjs legacy.js",
+		"compile": "tsup && cp dist/legacy/legacy.cjs legacy.js && cp dist/legacy/legacy.d.cts legacy.d.ts",
 		"test": "vitest run"
 	},
 	"repository": {

--- a/src/legacy.cts
+++ b/src/legacy.cts
@@ -1,3 +1,5 @@
-const traverse = require('./index.js');
+import traverse from './index';
 
-module.exports = traverse.default;
+export { default, TraverseContext, TraverseOptions } from './index';
+
+module.exports = traverse;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
 		"moduleResolution": "Bundler",
 		"allowSyntheticDefaultImports": true,
 		"esModuleInterop": true,
-		"verbatimModuleSyntax": true,
+		// Do not reenable this, breaks types for pre-4.5 TS
+		// "verbatimModuleSyntax": true,
 		"allowImportingTsExtensions": true,
 		"forceConsistentCasingInFileNames": true,
 		"strict": true,

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -48,9 +48,7 @@ export default defineConfig([
 		outExtension(ctx) {
 			return { js: ctx.format === 'cjs' ? '.cjs' : '.mjs' };
 		},
-		dts: {
-			banner: `export { default, type TraverseContext, type TraverseOptions } from '..';`,
-		},
+		dts: true,
 		sourcemap: false,
 		clean: true,
 		platform: 'neutral',


### PR DESCRIPTION
Before TypeScript 4.5 export maps were not supported. hence subpaths require publishign top level files. Previous PR shipped top level legacy.js, but didn't ship legacy.d.ts. Now we're doing that

Closes #8 